### PR TITLE
Fixed #78

### DIFF
--- a/OmniDB.userprefs
+++ b/OmniDB.userprefs
@@ -1,6 +1,6 @@
-﻿<Properties StartupConfiguration="{63F55D57-D1FF-43E5-929A-029E1DDEBC99}|" StartupItem="OmniDB/OmniDB.csproj">
+﻿<Properties StartupConfiguration="{63F55D57-D1FF-43E5-929A-029E1DDEBC99}|">
   <MonoDevelop.Ide.Workbench />
-  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" PreferredExecutionTarget="firefox" />
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Release" />
   <MonoDevelop.Ide.DebuggingService.Breakpoints>
     <BreakpointStore />
   </MonoDevelop.Ide.DebuggingService.Breakpoints>

--- a/OmniDatabase/MariaDB.cs
+++ b/OmniDatabase/MariaDB.cs
@@ -226,7 +226,7 @@ namespace OmniDatabase
                 v_filter = "and lower(c.table_name) = '" + p_table.ToLower() + "' ";
 
             return v_connection.Query (
-                "select c.table_name as table_name,                        " +
+                "select distinct c.table_name as table_name,               " +
                 "lower(c.column_name) as column_name,                      " +
                 "lower(c.data_type) as data_type,                          " +
                 "c.is_nullable as nullable,                                " +

--- a/OmniDatabase/MySQL.cs
+++ b/OmniDatabase/MySQL.cs
@@ -226,7 +226,7 @@ namespace OmniDatabase
 				v_filter = "and lower(c.table_name) = '" + p_table.ToLower() + "' ";
 
 			return v_connection.Query (
-				"select c.table_name as table_name,                        " +
+				"select distinct c.table_name as table_name,               " +
 				"lower(c.column_name) as column_name,                      " +
 				"lower(c.data_type) as data_type,                          " +
 				"c.is_nullable as nullable,                                " +


### PR DESCRIPTION
- Spartacus 0.43.23 removes calling to method `Cancel` on MariaDB and MySQL, which may cause connection loss.
- OmniDatabase supports some cases where columns are duplicated on `information_schema.columns`.