### PR TITLE
 Fix missing Posgresql 10 partitioned tables in browser

### DIFF
--- a/OmniDB/OmniDB_app/include/OmniDatabase/PostgreSQL.py
+++ b/OmniDB/OmniDB_app/include/OmniDatabase/PostgreSQL.py
@@ -271,8 +271,7 @@ class PostgreSQL:
                 on n.oid = c.relnamespace
                 and n.nspname = t.table_schema
                 where t.table_type = 'BASE TABLE'
-                  and not c.relispartition
-                  and c.relkind = ('r', 'p')
+                  and c.relkind in ('r', 'p')
                 {0}
                 order by 2, 1
             '''.format(v_filter), True)


### PR DESCRIPTION
The change fix the missing partitioned tables in browser for postgresql 10.
Not tested for other pg versions.