### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN  apt-get update \
 RUN mkdir /app
 WORKDIR /app
 
-RUN wget https://omnidb.org/dist/2.7.0/omnidb-server_2.7.0-debian-amd64.deb
+RUN wget -q https://omnidb.org/dist/2.8.0/omnidb-server_2.8.0-debian-amd64.deb
 
-RUN dpkg -i /app/omnidb-server_2.7.0-debian-amd64.deb
+RUN dpkg -i /app/omnidb-server_2.8.0-debian-amd64.deb
 
 EXPOSE 8000
 EXPOSE 25482


### PR DESCRIPTION
Update Dockerfile with OmniDB latest release version 2.8.
Set wget to be quiet, so focus only on error output (if any).