### PR TITLE
Updating Dockerfile by changing base image to Centos7. [Fixing issue …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM debian:stable-slim
+FROM centos:7
 
-RUN  apt-get update \
-  && apt-get install -y wget \
-  && rm -rf /var/lib/apt/lists/*
+RUN  yum -y install wget \
+  && yum clean all
 
 RUN mkdir /app
 WORKDIR /app
 
-RUN wget -q https://omnidb.org/dist/2.12.0/omnidb-server_2.12.0-debian-amd64.deb \
- && dpkg -i /app/omnidb-server_2.12.0-debian-amd64.deb \
- && rm -rf omnidb-server_2.12.0-debian-amd64.deb
+RUN  wget https://omnidb.org/dist/2.12.0/omnidb-server_2.12.0-centos7-amd64.rpm \
+  && rpm -Uvh /app/omnidb-server_2.12.0-centos7-amd64.rpm \
+  && rm -rf omnidb-server_2.12.0-centos7-amd64.rpm
 
 EXPOSE 8000
 EXPOSE 25482
 
-CMD ["omnidb-server"]
+CMD  omnidb-server -H 0.0.0.0 -p 8000


### PR DESCRIPTION
Here is the fix for the issue #674. The changes have been successfully tested on a RHEL machine.
Build the docker image with following command;
docker build -t omnidb/omnidb-server:2.12.0 .

And start the container with following command;
docker run -d -p 8080:8000 -p 25482:25482 --name omnidb omnidb/omnidb-server:2.12.0

OmniDB server will be up and running on port 8080.