### PR TITLE
add dockerignore and add group writable home dir for OpenShift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+Vagrantfile
+
+*.txt
+*.xlsx
+
+OmniDB
+omnidb_app
+omnidb_plugin
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /${SERVICE_USER}
 RUN  adduser --system --home /${SERVICE_USER} --no-create-home ${SERVICE_USER} \
   && mkdir -p /${SERVICE_USER} \
   && chown -R ${SERVICE_USER}.root /${SERVICE_USER} \
+  && chmod -R g+w /${SERVICE_USER} \
   && apt-get update \
   && apt-get -y upgrade \
   && apt-get install -y wget dumb-init \


### PR DESCRIPTION
* add dockerignore file to minimize data send to docker daemon as prebuilt omnidb app is downloaded for installation
* last patch was missing group writable home dir to work in OpenShift Kubernetes