### PR TITLE
Fix plugin linking with as-needed

### DIFF
--- a/omnidb_plugin/Makefile
+++ b/omnidb_plugin/Makefile
@@ -1,9 +1,10 @@
 EXTENSION = omnidb_plugin
 DATA = omnidb_plugin--0.0.1.sql
-MODULES = omnidb_plugin
+OBJS = omnidb_plugin.o
+MODULE_big = omnidb_plugin
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 override CPPFLAGS := $(CPPFLAGS) -I$(shell $(PG_CONFIG) --includedir)
-override LDFLAGS := $(LDFLAGS) -lpq
+SHLIB_LINK = -lpq
 include $(PGXS)


### PR DESCRIPTION
On systems where the linker defaults to "as-needed" (Ubuntu), we need to
put -lpq at the end of the command line. SHLIB_LINK is the correct PGXS
flag for that, but it depends on using OBJS and MODULE_big.

Otherwise, using the plugin fails with "cannot find symbol PQSignal".

Extends the fix from #919.