### PR TITLE
bugfix: add FROM key words to Compatible with postgres:8.4

### DIFF
--- a/OmniDB/OmniDB_app/include/Spartacus/Database.py
+++ b/OmniDB/OmniDB_app/include/Spartacus/Database.py
@@ -1693,9 +1693,9 @@ class PostgreSQL(Generic):
                 v_table = DataTable()
                 if self.v_cursor:
                     if p_blocksize > 0:
-                        self.v_cur.execute('FETCH {0} {1}'.format(p_blocksize, self.v_cursor))
+                        self.v_cur.execute('FETCH {0} FROM {1}'.format(p_blocksize, self.v_cursor))
                     else:
-                        self.v_cur.execute('FETCH ALL {0}'.format(self.v_cursor))
+                        self.v_cur.execute('FETCH ALL FROM {0}'.format(self.v_cursor))
                 if self.v_cur.description:
                     for c in self.v_cur.description:
                         v_table.AddColumn(c[0])


### PR DESCRIPTION
add 'FROM' keywords to compatible with postgres:8.4 😄
if without 'FROM' . version 8.4 (maybe 8.x ) . do `select * from xxx` will throw an error `syntax error at or near "OmniDB_xxxxx" LINE 1: FETCH 50 OmniDB_xxxxx`
