### PR TITLE
feat(Django4): manage django.conf.urls deprecation

### DIFF
--- a/OmniDB/OmniDB/urls.py
+++ b/OmniDB/OmniDB/urls.py
@@ -1,7 +1,7 @@
 """OmniDB URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+    https://docs.djangoproject.com/en/4.0/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
@@ -10,10 +10,11 @@ Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
+    1. Import the include() function: from django.urls import include, re_path as url
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import include, url
+from django.urls import include
+from django.urls import re_path as url
 from django.contrib import admin
 
 urlpatterns = [

--- a/OmniDB/OmniDB_app/urls.py
+++ b/OmniDB/OmniDB_app/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path as url
 from django.urls import include, path
 from . import views
 from django.conf import settings


### PR DESCRIPTION
As mentionned in https://github.com/OmniDB/OmniDB/issues/1310 django.conf.urls.url() was deprecated in Django 3.0, and is now removed in Django 4.0+.

A quick fix to this problem is to  replace `django.conf.urls` by `django.urls` and `from django.conf.urls import url` for `from django.urls import re_path as url` while keeping the rest of code unchanged.
