### PR TITLE
Remove website link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@
 
 
 
-**Website**: https://omnidb.org
 
 **Full Documentation**: https://omnidb.readthedocs.io
 


### PR DESCRIPTION
Remove outdated omnidb.org link from README

The omnidb.org domain is no longer controlled by the original project and currently redirects users to unrelated and potentially unsafe content (ads / adult pages).

To prevent confusion and reduce security risks for new users, this PR removes the link from the documentation.